### PR TITLE
Fix a double-fetch-from-drive bug and make the prefetch workers tunable.

### DIFF
--- a/drive_db/drive_db.go
+++ b/drive_db/drive_db.go
@@ -39,6 +39,7 @@ var (
 	driveCacheChunks   = flag.Int64("drivedb.fetchsize", 16, "Chunks of --drivedb.cachechunk bytes to read from drive at a time (aka readahead size; see also --drivedb.prefetchmultiplier).")
 	cacheSize          = flag.Int64("drivedb.maxcachesize", 16, "Chunks to cache from drive at a time.")
 	prefetchMultiplier = flag.Int64("drivedb.prefetchmultiplier", 4, "readahead multiplier; --drivedb.fetchsize chunks are fetched in sequence")
+	prefetchWorkers    = flag.Int("drivedb.prefetchworkers", 2, "number of prefetches to make in parallel")
 )
 
 type debugging bool
@@ -212,9 +213,10 @@ func NewDriveDB(client *http.Client, dbPath, cachePath string, pollInterval time
 	if debug {
 		registerDebugHandles(*d) // in http_handlers.go
 	}
-	// two!
-	go d.prefetcher()
-	go d.prefetcher()
+
+	for i := 0; i < *prefetchWorkers; i++ {
+		go d.prefetcher()
+	}
 	return d, nil
 }
 
@@ -1051,6 +1053,7 @@ func (d *DriveDB) readChunkImpl(fileId string, chunk, filesize int64) ([]byte, e
 
 	// map to larger drive read size
 	dchunk := d.chunkToDriveChunk(chunk)
+	log.Printf("reading chunk %d from drive", dchunk)
 	data, err = d.getChunkFromDrive(fileId, dchunk, filesize)
 	if err != nil {
 		log.Printf("error reading from drive: %v", err)
@@ -1085,8 +1088,9 @@ func (d *DriveDB) prefetcher() {
 				continue
 			}
 			// if it isn't, get it.
-			debug.Printf("prefetching %s drive block %d", s.fileId, newchunk)
-			data, err := d.getChunkFromDrive(s.fileId, newchunk, s.filesize)
+			log.Printf("prefetching %s drive block %d", s.fileId, newchunk)
+			// we don't care about the data; getChunkFromDrive writes it to cache.
+			_, err = d.getChunkFromDrive(s.fileId, newchunk, s.filesize)
 			if err != nil {
 				log.Printf("prefetch error: %v", err)
 				d.Lock()
@@ -1094,7 +1098,6 @@ func (d *DriveDB) prefetcher() {
 				d.Unlock()
 				continue
 			}
-			d.writeChunks(s.fileId, newchunk, data)
 			d.Lock()
 			delete(d.pfetchmap, key)
 			d.Unlock()
@@ -1169,7 +1172,7 @@ func (d *DriveDB) getChunkFromDriveImpl(fileId string, chunk, filesize int64) ([
 	}
 	spec := fmt.Sprintf("bytes=%d-%d", start, end)
 	req.Header.Add("Range", spec)
-	debug.Printf("reading %v %s", fileId, spec)
+	// log.Printf("reading %v %s", fileId, spec)
 
 	resp, err := d.client.Do(req)
 	if err != nil {

--- a/drive_db/drive_db.go
+++ b/drive_db/drive_db.go
@@ -1053,7 +1053,7 @@ func (d *DriveDB) readChunkImpl(fileId string, chunk, filesize int64) ([]byte, e
 
 	// map to larger drive read size
 	dchunk := d.chunkToDriveChunk(chunk)
-	log.Printf("reading chunk %d from drive", dchunk)
+	debug.Printf("reading chunk %d from drive", dchunk)
 	data, err = d.getChunkFromDrive(fileId, dchunk, filesize)
 	if err != nil {
 		log.Printf("error reading from drive: %v", err)
@@ -1088,8 +1088,8 @@ func (d *DriveDB) prefetcher() {
 				continue
 			}
 			// if it isn't, get it.
-			log.Printf("prefetching %s drive block %d", s.fileId, newchunk)
 			// we don't care about the data; getChunkFromDrive writes it to cache.
+			debug.Printf("prefetching %s drive block %d", s.fileId, newchunk)
 			_, err = d.getChunkFromDrive(s.fileId, newchunk, s.filesize)
 			if err != nil {
 				log.Printf("prefetch error: %v", err)
@@ -1172,7 +1172,7 @@ func (d *DriveDB) getChunkFromDriveImpl(fileId string, chunk, filesize int64) ([
 	}
 	spec := fmt.Sprintf("bytes=%d-%d", start, end)
 	req.Header.Add("Range", spec)
-	// log.Printf("reading %v %s", fileId, spec)
+	debug.Printf("reading %v %s", fileId, spec)
 
 	resp, err := d.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
We were writing the cache twice, causing confusion.